### PR TITLE
Fix to compile with servant >= 0.12

### DIFF
--- a/servant-rawm.cabal
+++ b/servant-rawm.cabal
@@ -42,6 +42,7 @@ library
                      , servant-server >= 0.9
                      , wai >= 3.2
                      , wai-app-static >= 3.1
+                     , servant-client-core
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction -Wmissing-import-lists
 

--- a/src/Servant/RawM/Internal/Client.hs
+++ b/src/Servant/RawM/Internal/Client.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -23,7 +25,7 @@ import Network.HTTP.Client (Response)
 import Network.HTTP.Media (MediaType)
 import Network.HTTP.Types (Header, Method)
 import Servant.Client (Client, ClientM, HasClient(clientWithRoute))
-import Servant.Common.Req (Req, performRequest)
+import Servant.Client.Core (RunClient, Request)
 
 import Servant.RawM.Internal.API (RawM')
 
@@ -31,21 +33,22 @@ import Servant.RawM.Internal.API (RawM')
 --
 -- >>> :set -XTypeOperators
 -- >>> import Data.Type.Equality ((:~:)(Refl))
--- >>> Refl :: Client (RawM' a) :~: (Method -> (Req -> Req) -> ClientM (Int, ByteString, MediaType, [Header], Response ByteString))
+-- >>> Refl :: Client (RawM' a) :~: (Method -> (Request -> Request) -> ClientM (Int, ByteString, MediaType, [Header], Response ByteString))
 -- Refl
 --
--- This allows modification of the underlying 'Req' to work for any sort of
+-- This allows modification of the underlying 'Request' to work for any sort of
 -- 'Network.Wai.Application'.
 --
 -- Check out the
 -- <https://github.com/cdepillabout/servant-rawm/tree/master/example example> in
 -- the source code repository that shows a more in-depth server, client, and
 -- documentation.
-instance HasClient (RawM' serverType) where
-  type Client (RawM' serverType) =
+instance RunClient m => HasClient m (RawM' serverType) where
+  type Client m (RawM' serverType) =
         Method
-    -> (Req -> Req)
+    -> (Request -> Request)
     -> ClientM (Int, ByteString, MediaType, [Header], Response ByteString)
 
-  clientWithRoute :: Proxy (RawM' serverType) -> Req -> Client (RawM' serverType)
-  clientWithRoute Proxy req method f = performRequest method $ f req
+  clientWithRoute = undefined
+  -- clientWithRoute :: Proxy (RawM' serverType) -> Request -> Client m (RawM' serverType)
+  -- clientWithRoute Proxy req method f = performRequest method $ f req

--- a/src/Servant/RawM/Internal/Client.hs
+++ b/src/Servant/RawM/Internal/Client.hs
@@ -19,14 +19,9 @@ This module only exports a 'HasClient' instance for 'RawM'.
 
 module Servant.RawM.Internal.Client where
 
-import Data.ByteString.Lazy (ByteString)
 import Data.Proxy (Proxy(Proxy))
-import Network.HTTP.Client (Response)
-import Network.HTTP.Media (MediaType)
-import Network.HTTP.Types (Header, Method)
 import Servant.Client (Client, ClientM, HasClient(clientWithRoute))
-import Servant.Client.Core (RunClient, Request)
-
+import Servant.Client.Core (runRequest, RunClient, Request, Response)
 import Servant.RawM.Internal.API (RawM')
 
 -- | Creates a client route like the following:
@@ -44,11 +39,15 @@ import Servant.RawM.Internal.API (RawM')
 -- the source code repository that shows a more in-depth server, client, and
 -- documentation.
 instance RunClient m => HasClient m (RawM' serverType) where
-  type Client m (RawM' serverType) =
-        Method
-    -> (Request -> Request)
-    -> ClientM (Int, ByteString, MediaType, [Header], Response ByteString)
+  type Client m (RawM' serverType) = (Request -> Request) -> ClientM Response
 
-  clientWithRoute = undefined
-  -- clientWithRoute :: Proxy (RawM' serverType) -> Request -> Client m (RawM' serverType)
-  -- clientWithRoute Proxy req method f = performRequest method $ f req
+  clientWithRoute
+    :: Proxy m
+      -> Proxy (RawM' serverType)
+      -> Request
+      -> (Request -> Request)
+      -> ClientM Response
+
+  clientWithRoute Proxy Proxy r f = runRequest (f r)
+
+  -- hoistClientMethod = undefined

--- a/src/Servant/RawM/Internal/Server.hs
+++ b/src/Servant/RawM/Internal/Server.hs
@@ -31,7 +31,7 @@ import Network.Wai
 import Network.Wai.Application.Static
        (StaticSettings, defaultFileServerSettings, defaultWebAppSettings,
         embeddedSettings, staticApp, webAppSettingsWithLookup)
-import Servant (Context, HasServer(route), Handler, ServerT, runHandler)
+import Servant (Context, HasServer(route, hoistServerWithContext), Handler, ServerT, runHandler)
 import Servant.Server.Internal
        (Delayed, Router'(RawRouter), RouteResult(Fail, FailFatal, Route), responseServantErr,
         runDelayed)
@@ -74,7 +74,13 @@ instance HasServer (RawM' serverType) context where
                 case eitherApp of
                   Left err -> respond . Route $ responseServantErr err
                   Right app -> app request (respond . Route)
-
+  hoistServerWithContext
+    :: Proxy (RawM' serverType)
+      -> Proxy context
+      -> (forall x. m x -> n x)
+      -> m Application
+      -> n Application
+  hoistServerWithContext Proxy Proxy f m = f m
 
 -- | Serve anything under the specified directory as a 'RawM'' endpoint.
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-9.2
+resolver: lts-12.7
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,8 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- servant-client-core-0.14.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This breaks the client functionality entirely.  However, it compiles and
allows you to use RawM in the server.

Works toward fixing #4