### PR TITLE
Fix compilation with servant-client-core >= 0.18.1

### DIFF
--- a/servant-rawm-client/servant-rawm-client.cabal
+++ b/servant-rawm-client/servant-rawm-client.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules:     Servant.RawM.Client
   build-depends:       base >= 4.8 && < 5
                      , servant-rawm >= 1.0
-                     , servant-client-core >= 0.16
+                     , servant-client-core >= 0.16 && < 0.19
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction
 

--- a/servant-rawm-client/src/Servant/RawM/Client.hs
+++ b/servant-rawm-client/src/Servant/RawM/Client.hs
@@ -28,7 +28,8 @@ module Servant.RawM.Client (
 import Data.Proxy          (Proxy (Proxy))
 import Servant.Client.Core (Client,
                             HasClient (clientWithRoute, hoistClientMonad),
-                            Request, Response, RunClient, runRequest)
+                            Request, Response, RunClient)
+import Servant.Client.Core.RunClient (runRequest)
 import Servant.RawM
 
 -- | Creates a client route like the following:


### PR DESCRIPTION
Fixing https://github.com/cdepillabout/servant-rawm/issues/19

Starting from 0.18.1 servant-client-core no longer exposes `runRequest` from `Servant.Client.Core` (do CTRL+F runRequest in haddock index https://hackage.haskell.org/package/servant-client-core-0.18.1/docs/doc-index.html)

But we can make this package compile with all `servant-client-core` versions between 0.16.0 and 0.18.2 by importing it from this module.